### PR TITLE
Fix login persistence on refresh and unregister stale service workers

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -8,8 +8,13 @@ export function useAuth() {
   const user = useState<User | null>('auth-user', () => null)
 
   async function fetchUser() {
+    // Use useRequestFetch so that during SSR the incoming request's
+    // session cookie is forwarded to /api/auth/me. Bare $fetch on the
+    // server does not forward cookies, which causes login state to be
+    // lost on page refresh.
+    const request = useRequestFetch()
     try {
-      user.value = await $fetch<User | null>('/api/auth/me')
+      user.value = await request<User | null>('/api/auth/me')
     } catch {
       user.value = null
     }

--- a/app/composables/useLists.ts
+++ b/app/composables/useLists.ts
@@ -25,7 +25,9 @@ export function useLists() {
   const lists = useState<ShoppingList[]>('lists', () => [])
 
   async function fetchLists() {
-    const data = await $fetch<ShoppingList[]>('/api/lists')
+    // Use useRequestFetch so the session cookie is forwarded during SSR.
+    const request = useRequestFetch()
+    const data = await request<ShoppingList[]>('/api/lists')
     lists.value = data
     return data
   }

--- a/server/routes/dev-sw.js.ts
+++ b/server/routes/dev-sw.js.ts
@@ -1,0 +1,38 @@
+// Self-unregistering service worker shim.
+//
+// Some browsers have a stale service worker registered on localhost from a
+// previous project (e.g. one that used vite-plugin-pwa / @vite-pwa/nuxt).
+// That SW intercepts requests and caches responses with wrong MIME types,
+// which breaks JS module loading in Safari and causes auth/cookie weirdness.
+//
+// When the browser fetches the SW script to update it, we return this
+// payload, which unregisters itself, clears all caches, and reloads open
+// tabs. After that the site behaves normally. See also server/routes/sw.js.ts
+// which shares the same handler in case the stale SW was registered at /sw.js.
+const SCRIPT = `
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    try {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+    } catch {}
+    try {
+      await self.registration.unregister()
+    } catch {}
+    try {
+      const clients = await self.clients.matchAll({ type: 'window' })
+      for (const client of clients) {
+        try { client.navigate(client.url) } catch {}
+      }
+    } catch {}
+  })())
+})
+self.addEventListener('fetch', () => {})
+`
+
+export default defineEventHandler((event) => {
+  setResponseHeader(event, 'Content-Type', 'application/javascript; charset=utf-8')
+  setResponseHeader(event, 'Cache-Control', 'no-cache, no-store, must-revalidate')
+  return SCRIPT
+})

--- a/server/routes/sw.js.ts
+++ b/server/routes/sw.js.ts
@@ -1,0 +1,30 @@
+// See server/routes/dev-sw.js.ts for full context — identical self-
+// unregistering shim served at /sw.js in case the stale service worker
+// from a previous project on localhost was registered at that path.
+const SCRIPT = `
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    try {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+    } catch {}
+    try {
+      await self.registration.unregister()
+    } catch {}
+    try {
+      const clients = await self.clients.matchAll({ type: 'window' })
+      for (const client of clients) {
+        try { client.navigate(client.url) } catch {}
+      }
+    } catch {}
+  })())
+})
+self.addEventListener('fetch', () => {})
+`
+
+export default defineEventHandler((event) => {
+  setResponseHeader(event, 'Content-Type', 'application/javascript; charset=utf-8')
+  setResponseHeader(event, 'Cache-Control', 'no-cache, no-store, must-revalidate')
+  return SCRIPT
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -4,6 +4,15 @@ const SESSION_CONFIG = {
   password: process.env.NUXT_SESSION_PASSWORD || 'change-me-to-a-random-string-at-least-32-chars-long!!',
   name: 'shopping-helper-session',
   maxAge: 60 * 60 * 24 * 7, // 7 days
+  cookie: {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax' as const,
+    // h3's default is secure: true, which prevents the cookie from being
+    // stored over plain HTTP (including localhost in Safari). Only require
+    // secure transport in production deploys.
+    secure: process.env.NODE_ENV === 'production',
+  },
 }
 
 interface SessionData {


### PR DESCRIPTION
## Summary
- Forward session cookies during SSR in `useAuth`/`useLists` via `useRequestFetch` so login state survives a page refresh (bare `$fetch` on the server doesn't forward the incoming request's cookies).
- Make the session cookie's `secure` flag conditional on `NODE_ENV=production` — h3's default of `secure: true` prevents Safari from storing the cookie on localhost over plain HTTP.
- Add self-unregistering service worker shims at `/sw.js` and `/dev-sw.js` to clear stale workers registered by previous localhost projects (they were intercepting requests with wrong MIME types and breaking module loading / auth).

## Test plan
- [ ] Log in, refresh the page, confirm you remain logged in (tested in Safari + Chrome on localhost)
- [ ] After deploying, confirm session cookie is still set with `Secure` in production
- [ ] With a stale SW previously registered on localhost, load the site and confirm it unregisters and the tab reloads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)