### PR TITLE
fix: restore tick-item toast and checked-state persistence

### DIFF
--- a/app/components/ItemRow.vue
+++ b/app/components/ItemRow.vue
@@ -15,9 +15,11 @@ const emit = defineEmits<{
 const { updateItem, deleteItem } = useItems(props.listId)
 
 async function handleCheck() {
+  // Emit synchronously before awaiting — the websocket echo (useListSync)
+  // may unmount this row before the await resolves, which would drop the emit.
+  emit('checked', props.item.id)
   try {
     await updateItem(props.item.id, { checked: true })
-    emit('checked', props.item.id)
   } catch (e: any) {
     toast.error('Failed to check item')
   }
@@ -34,7 +36,7 @@ async function handleDelete() {
 
 <template>
   <div class="flex items-center gap-3 rounded-lg border px-3 py-2">
-    <Checkbox @update:checked="handleCheck" />
+    <Checkbox @update:model-value="handleCheck" />
     <div class="flex-1 min-w-0">
       <span class="text-sm">{{ item.name }}</span>
       <Badge v-if="item.quantity > 1" variant="secondary" class="ml-2 text-xs">

--- a/app/components/ui/sonner/Sonner.vue
+++ b/app/components/ui/sonner/Sonner.vue
@@ -2,6 +2,7 @@
 import type { ToasterProps } from "vue-sonner"
 import { CircleCheckIcon, InfoIcon, Loader2Icon, OctagonXIcon, TriangleAlertIcon, XIcon } from "lucide-vue-next"
 import { Toaster as Sonner } from "vue-sonner"
+import "vue-sonner/style.css"
 import { cn } from "@/lib/utils"
 
 const props = defineProps<ToasterProps>()

--- a/app/composables/useItems.ts
+++ b/app/composables/useItems.ts
@@ -35,14 +35,15 @@ export function useItems(listId: string) {
       method: 'PUT',
       body: data,
     })
-    if (data.checked) {
-      // Remove from visible list immediately
-      items.value = items.value.filter((i) => i.id !== itemId)
-    } else {
+    if (!data.checked) {
       const idx = items.value.findIndex((i) => i.id === itemId)
       if (idx !== -1) items.value[idx] = updated
     }
     return updated
+  }
+
+  function hideItem(itemId: string) {
+    items.value = items.value.filter((i) => i.id !== itemId)
   }
 
   async function deleteItem(itemId: string) {
@@ -62,5 +63,5 @@ export function useItems(listId: string) {
     return updated
   }
 
-  return { items, setItems, addItem, updateItem, deleteItem, uncheckItem }
+  return { items, setItems, addItem, updateItem, deleteItem, uncheckItem, hideItem }
 }

--- a/app/pages/lists/[id].vue
+++ b/app/pages/lists/[id].vue
@@ -4,7 +4,7 @@ import { toast } from 'vue-sonner'
 
 const route = useRoute()
 const listId = route.params.id as string
-const { items, setItems, uncheckItem } = useItems(listId)
+const { items, setItems, uncheckItem, hideItem } = useItems(listId)
 const { user } = useAuth()
 
 const { data: list, error } = await useFetch(`/api/lists/${listId}`)
@@ -24,6 +24,7 @@ const isOwner = computed(() => (list.value as any)?.ownerId === user.value?.id)
 const { connected } = useListSync(listId)
 
 function handleItemChecked(itemId: string) {
+  hideItem(itemId)
   toast('Item completed', {
     duration: 5000,
     action: {


### PR DESCRIPTION
## Summary
- Ticking a list item did nothing — no toast, no persistence on refresh. Fixed three compounding bugs.
- `ItemRow` listened for `@update:checked` but reka-ui's `Checkbox` emits `update:modelValue` — the handler never ran.
- After fixing the event name, `useListSync`'s websocket echo filtered the item out of the list before `await updateItem()` resolved, unmounting the row and dropping the `checked` emit before the parent could receive it. Emit now fires synchronously before the await.
- `vue-sonner/style.css` was never imported, so the toaster had no `position: fixed` and toasts rendered off-screen.
- Refactor: split the hide-on-check side effect out of `useItems.updateItem` into a `hideItem` helper called from the page, so the composable is just the API call and UI concerns live where the toast is shown.

## Test plan
- [x] Tick a list item → "Item completed" toast with "Undo" appears at bottom-right
- [x] Item disappears from list immediately
- [x] Click "Undo" within 5s → item restored
- [x] Let toast auto-dismiss → item stays hidden
- [x] Refresh page → checked item stays hidden (server filter on `checked: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)