### PR TITLE
Show globe indicator for shared-with-all lists

### DIFF
--- a/app/components/ListCard.vue
+++ b/app/components/ListCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { MoreVertical, Trash2, Pencil } from 'lucide-vue-next'
+import { MoreVertical, Trash2, Pencil, Globe } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import type { ShoppingList } from '@/composables/useLists'
 
@@ -77,6 +77,15 @@ async function handleRename() {
               :username="member.username"
               :is-owner="member.isOwner"
             />
+            <Avatar
+              v-if="list.sharedWithAll"
+              class="border-2 border-background h-7 w-7"
+              title="Shared with all users"
+            >
+              <AvatarFallback>
+                <Globe class="h-3.5 w-3.5" />
+              </AvatarFallback>
+            </Avatar>
           </div>
         </div>
       </CardContent>

--- a/app/pages/lists/[id].vue
+++ b/app/pages/lists/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft, Globe } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 
 const route = useRoute()
@@ -63,6 +63,15 @@ function handleItemChecked(itemId: string) {
             :username="share.user.username"
             size="sm"
           />
+          <Avatar
+            v-if="(list as any).sharedWithAll"
+            class="border-2 border-background h-6 w-6"
+            title="Shared with all users"
+          >
+            <AvatarFallback class="text-[9px]">
+              <Globe class="h-3 w-3" />
+            </AvatarFallback>
+          </Avatar>
         </div>
       </div>
       <ListShareDialog v-if="isOwner" :list-id="listId" />


### PR DESCRIPTION
## Summary

- When a list has `sharedWithAll: true`, a globe icon avatar now appears in the member avatar row on both the list card and the list detail page
- Previously only explicitly shared users were shown, giving no visual indication that the list was visible to everyone

## Test plan

- [ ] Create a list with "shared with all" enabled — verify globe icon appears on the list card
- [ ] Open that list — verify globe icon appears in the header avatar row
- [ ] Create a normal shared list (not shared with all) — verify no globe icon appears
- [ ] Create a personal list — verify no globe icon appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)